### PR TITLE
Swapped VM size from B1s to B1ms

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -534,7 +534,7 @@
             ],
             "properties": {
                 "hardwareProfile": {
-                    "vmSize": "Standard_B1s"
+                    "vmSize": "Standard_B1ms"
                 },
                 "storageProfile": {
                     "imageReference": {


### PR DESCRIPTION
While performing the lab, I stumbled upon an error while enabling the replication on the two virtual machines. Error 151254, possible cause was insufficient memory to install the Azure Mobility agent.